### PR TITLE
🐛Fix: Pass the VITE_MUI_PRO_LICENCE env in the Release workflow 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VITE_MUI_PRO_LICENCE: ${{ secrets.VITE_MUI_PRO_LICENCE }}
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
 


### PR DESCRIPTION
🐛Fix: Pass the VITE_MUI_PRO_LICENCE env in the Release workflow  - so that releases actually get the pro features 🤦

Signed-off-by: Jens Brimfors <jens.brimfors@qapital.com>